### PR TITLE
Getting resources from relative path

### DIFF
--- a/web/src/main/bvmui/vue.config.js
+++ b/web/src/main/bvmui/vue.config.js
@@ -1,3 +1,5 @@
+const DEV_MODE = process.env.NODE_ENV !== "production";
+
 const argv = require("yargs").argv;
 const devTarget = argv.s || "http://localhost:8086";
 
@@ -10,6 +12,7 @@ module.exports = {
       }
     }
   },
+  publicPath: DEV_MODE ? "/" : "",
   configureWebpack: {
     performance: {
       hints: false


### PR DESCRIPTION
### Motivation

When you deploy the resouruces path are only from '/'

### Solution

Added publicPath to vue.config so that in production (when you build the WAR) the resources are downladed from the relative path