### PR TITLE
Make it optional to refresh metadata at boot

### DIFF
--- a/standalone/src/main/resources/conf/server.properties
+++ b/standalone/src/main/resources/conf/server.properties
@@ -1,10 +1,13 @@
 # ZooKeeper connection
 metadataServiceUri=zk+null://127.0.0.1:2181/ledgers
 
+# Refresh Metadata at every boot
+# if you set this flag to 'false' metadata will be refreshed only when requested
+metdata.refreshAtBoot=true
+
 # Jetty Server
 http.port=4500
 http.host=localhost
-
 
 # Users
 user.1.username=admin

--- a/web/src/main/java/org/bkvm/api/listeners/ContextInitializer.java
+++ b/web/src/main/java/org/bkvm/api/listeners/ContextInitializer.java
@@ -75,7 +75,7 @@ public class ContextInitializer implements ServletContextListener {
             BookkeeperManager bookkeeperManager = new BookkeeperManager(configStore, metadataCache);
             context.setAttribute("bookkeeper", bookkeeperManager);
 
-            boolean refreshAtBoot = Boolean.parseBoolean(configStore.getProperty("metdata.refreshAtBoot", "true"));
+            boolean refreshAtBoot = Boolean.parseBoolean(configStore.getProperty("metdata.refreshAtBoot", "false"));
             context.log("metdata.refreshAtBoot=" + refreshAtBoot);
             if (refreshAtBoot) {
                 // launch reload in background

--- a/web/src/main/java/org/bkvm/api/listeners/ContextInitializer.java
+++ b/web/src/main/java/org/bkvm/api/listeners/ContextInitializer.java
@@ -75,8 +75,12 @@ public class ContextInitializer implements ServletContextListener {
             BookkeeperManager bookkeeperManager = new BookkeeperManager(configStore, metadataCache);
             context.setAttribute("bookkeeper", bookkeeperManager);
 
-            // launch reload in background
-            bookkeeperManager.refreshMetadataCache();
+            boolean refreshAtBoot = Boolean.parseBoolean(configStore.getProperty("metdata.refreshAtBoot", "true"));
+            context.log("metdata.refreshAtBoot=" + refreshAtBoot);
+            if (refreshAtBoot) {
+                // launch reload in background
+                bookkeeperManager.refreshMetadataCache();
+            }
         } catch (Throwable ex) {
             ex.printStackTrace();
             throw new RuntimeException("Unexpected error occurred " + ex, ex);

--- a/web/src/main/java/org/bkvm/api/resources/LedgersResource.java
+++ b/web/src/main/java/org/bkvm/api/resources/LedgersResource.java
@@ -30,8 +30,8 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import org.apache.bookkeeper.client.api.LedgerMetadata;
-import org.bkvm.bookkeeper.BookkeeperException;
 import org.bkvm.bookkeeper.BookkeeperManager;
+import org.bkvm.bookkeeper.BookkeeperManagerException;
 import org.bkvm.cache.Ledger;
 
 @Path("ledger")
@@ -77,7 +77,7 @@ public class LedgersResource extends AbstractBookkeeperResource {
         return convertLedgerBean(ledgerId, ledgerMetadata);
     }
 
-    private LedgerBean convertLedgerBean(long ledgerId, Ledger ledger) throws BookkeeperException {
+    private LedgerBean convertLedgerBean(long ledgerId, Ledger ledger) throws BookkeeperManagerException {
         LedgerMetadata ledgerMetadata = getBookkeeperManger().getLedgerMetadata(ledger);
         LedgerBean b = new LedgerBean();
         b.setId(ledgerId);

--- a/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManagerException.java
+++ b/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManagerException.java
@@ -23,13 +23,13 @@ package org.bkvm.bookkeeper;
  *
  * @author matteo.minardi
  */
-public class BookkeeperException extends Exception {
+public class BookkeeperManagerException extends Exception {
 
-    public BookkeeperException(Throwable cause) {
+    public BookkeeperManagerException(Throwable cause) {
         super(cause);
     }
 
-    public BookkeeperException(String cause) {
+    public BookkeeperManagerException(String cause) {
         super(cause);
     }
 


### PR DESCRIPTION
- Do not prevent bootstrap in case of ZooKeeper connection issues
- Add flag to not refresh metadata at boot
- rename BookKeeperException to BookkeeperManagerException