### PR TITLE
Provide basic Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,28 @@
+
+FROM ubuntu:20.04
+
+ARG TARBALL
+RUN test -n "$TARBALL"
+
+
+ENV WEB_PORT=4500
+EXPOSE $WEB_PORT
+ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
+
+RUN apt-get update \
+     && apt-get -y dist-upgrade \
+     && apt-get -y install --no-install-recommends openjdk-11-jdk-headless netcat dnsutils less curl unzip \
+     && apt-get -y --purge autoremove \
+     && apt-get autoclean \
+     && apt-get clean \
+     && rm -rf /var/lib/apt/lists/*
+
+
+ADD ${TARBALL} /
+RUN mkdir /bkvm
+RUN unzip /bkvm-* && cd /bkvm-*/ && mv ./* /bkvm && rm -rf /bkvm-*
+COPY entrypoint.sh /bkvm/entrypoint.sh
+
+WORKDIR /bkvm
+ENTRYPOINT [ "/bkvm/entrypoint.sh" ]
+CMD ["/bkvm/bin/service", "server", "console"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+env | while IFS='=' read -r n v; do
+    if [[ "$n" == BKVM_* ]]; then
+      property=${n/BKVM_/}
+      property=${property/\./_}
+      escaped_value=$(printf '%s\n' "$v" | sed -e 's/[\/&]/\\&/g')
+      sed -i "s/$property.*/$property=$escaped_value/g" /bkvm/conf/server.properties
+      printf "Replacing configuration entry %s with %s\n" "$property" "$v"
+    fi
+done
+
+exec "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -3,10 +3,10 @@ set -e
 env | while IFS='=' read -r n v; do
     if [[ "$n" == BKVM_* ]]; then
       property=${n/BKVM_/}
-      property=${property/\./_}
+      property=${property/_/\.}
       escaped_value=$(printf '%s\n' "$v" | sed -e 's/[\/&]/\\&/g')
       sed -i "s/$property.*/$property=$escaped_value/g" /bkvm/conf/server.properties
-      printf "Replacing configuration entry %s with %s\n" "$property" "$v"
+      printf "Setting configuration entry %s: %s\n" "$property" "$v"
     fi
 done
 

--- a/standalone/src/main/resources/bin/java-utils.sh
+++ b/standalone/src/main/resources/bin/java-utils.sh
@@ -69,7 +69,7 @@ done
 SERVICE=$1
 shift
 
-if [ "x$DAEMON_MODE" = "xtrue" ]; then
+if [ "$DAEMON_MODE" = "true" ]; then
   CONSOLE_OUTPUT_FILE=$SERVICE.service.log  
   nohup $JAVA -cp $CLASSPATH $JAVA_OPTS "$@" > "$CONSOLE_OUTPUT_FILE" 2>&1 < /dev/null &
   RETVAL=$?

--- a/standalone/src/main/resources/conf/server.properties
+++ b/standalone/src/main/resources/conf/server.properties
@@ -18,7 +18,7 @@ metadata.refreshPeriodSeconds=300
 
 # Jetty Server
 http.port=4500
-http.host=localhost
+http.host=0.0.0.0
 
 #configurable roles are: Admin (Administrator role),User (read-only role)
 # Users


### PR DESCRIPTION
* Created a Dockerfile which runs the service, based on Ubuntu and JDK11
* By the default we expose the port 4500 which is where the UI is reachable
* You can override the server properties using env variable with the BKVM_ prefix

Example:
```
# Start BookKeeper standalone
docker run --rm --network mynet --hostname bk -p 2181 apache/bookkeeper:latest standalon

# Start BKVM
docker run --rm -p 4500 -e BKVM_metadataServiceUri='zk+null://bk:21
81/ledgers' -e BKVM_http_host=0.0.0.0 --network mynet -it nicoloboschi/bkvm:latest
```