### PR TITLE
fix: deleted ledgers are not removed from the cache

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,6 @@ RUN test -n "$TARBALL"
 
 ENV WEB_PORT=4500
 EXPOSE $WEB_PORT
-ENV JAVA_HOME /usr/lib/jvm/java-11-openjdk-amd64
 
 RUN apt-get update \
      && apt-get -y dist-upgrade \

--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -1,0 +1,48 @@
+version: '3'
+services:
+  zk:
+    image: zookeeper:3.9.2
+    hostname: zk
+    ports:
+      - "2181:2181"
+    healthcheck:
+      test: ["CMD", "curl", "-sf", "http://localhost:8080/commands/stat"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+    restart: always
+
+  bookie-1:
+    image: apache/bookkeeper:4.16.5
+    hostname: bk-1
+    ports:
+      - "3181:3181"
+      - "8080:8080"
+    environment:
+      - BK_zkServers=zk:2181
+      - BK_metadataServiceUri=zk+null://zk:2181/ledgers
+      - BK_DATA_DIR=/data/bookkeeper
+      - BK_useHostNameAsBookieID=true
+      - BK_bookiePort=3181
+      - BK_httpServerEnabled=true
+    depends_on:
+      - "zk"
+    restart: always
+
+  bookie-1-insert:
+    image: apache/bookkeeper:4.16.5
+    depends_on:
+      - bookie-1
+    restart: on-failure
+    environment:
+      - BK_zkServers=zk:2181
+      - BK_metadataServiceUri=zk+null://zk:2181/ledgers
+    entrypoint: [ "bash", "-c", "source /opt/bookkeeper/scripts/common.sh && bin/bookkeeper shell simpletest -e 1 -a 1 -w 1" ]
+
+  bkvm:
+    ports:
+      - "4500:4500"
+    image: bkvm/bkvm:latest
+    environment:
+      BKVM_metadataServiceUri: zk://zk:2181/ledgers
+

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <jersey.version>2.35</jersey.version>
         <libs.checkstyle>3.1.1</libs.checkstyle>
         <libs.spotbugs>4.1.4</libs.spotbugs>
-        <eclipselink.version>2.7.5</eclipselink.version>
+        <eclipselink.version>2.7.14</eclipselink.version>
         <libs.spotbugsannotations>3.1.7</libs.spotbugsannotations>
 
         <libs.jaxws.jaxb-api>2.3.1</libs.jaxws.jaxb-api>
@@ -70,7 +70,7 @@
         <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
         <bc-fips.version>1.0.2.3</bc-fips.version>
         <guava.version>33.1.0-jre</guava.version>
-        <protobuf-java.version>3.19.6</protobuf-java.version>
+        <protobuf-java.version>3.24.0</protobuf-java.version>
         <kotlin-stdlib-jdk8.version>1.6.10</kotlin-stdlib-jdk8.version>
         <kubernetes-client.version>6.5.0</kubernetes-client.version>
     </properties>
@@ -107,7 +107,7 @@
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>
                 <artifactId>org.eclipse.persistence.asm</artifactId>
-                <version>${eclipselink.version}</version>
+                <version>9.7.0</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.persistence</groupId>

--- a/web/src/main/java/org/bkvm/auth/AuthManager.java
+++ b/web/src/main/java/org/bkvm/auth/AuthManager.java
@@ -57,7 +57,7 @@ public final class AuthManager {
     }
 
     private boolean checkUserRole(String role) {
-        return EnumUtils.isValidEnum(UserRole.class, role);
+        return UserRole.Fields.isValidRole(role);
     }
 
     public boolean login(String username, String password) {

--- a/web/src/main/java/org/bkvm/auth/AuthManager.java
+++ b/web/src/main/java/org/bkvm/auth/AuthManager.java
@@ -23,7 +23,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import org.apache.commons.lang3.EnumUtils;
 import org.bkvm.config.ConfigurationStore;
 
 /**

--- a/web/src/main/java/org/bkvm/auth/UserRole.java
+++ b/web/src/main/java/org/bkvm/auth/UserRole.java
@@ -19,10 +19,15 @@
  */
 package org.bkvm.auth;
 
-import lombok.experimental.FieldNameConstants;
+import java.util.Set;
 
-@FieldNameConstants
-public enum UserRole {
-    @FieldNameConstants.Include Admin,
-    @FieldNameConstants.Include User
+public class UserRole {
+    public static class Fields {
+        public static final String Admin = "Admin";
+        public static final String User = "User";
+        private static final Set<String> ALL = Set.of(Admin, User);
+        public static boolean isValidRole(String role) {
+            return ALL.contains(role);
+        }
+    }
 }

--- a/web/src/main/java/org/bkvm/bookkeeper/BookkeeperClusterPool.java
+++ b/web/src/main/java/org/bkvm/bookkeeper/BookkeeperClusterPool.java
@@ -65,7 +65,7 @@ public class BookkeeperClusterPool implements Closeable {
                     conf.setProperty(p, properties.get(p));
                 }
             } catch (IOException ex) {
-                LOG.log(Level.INFO, "Wrong configuration passed {0}", configuration);
+                LOG.log(Level.SEVERE, "Wrong configuration passed {0}", configuration);
             }
 
             LOG.log(Level.INFO, "Creating cluster {0}, at {1}", new Object[]{clusterId, metadataServiceUri});

--- a/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManager.java
+++ b/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManager.java
@@ -129,6 +129,7 @@ public class BookkeeperManager implements AutoCloseable {
         IDLE,
         WORKING
     }
+
     private volatile long lastMetadataCacheRefresh;
     private final ConcurrentHashMap<Integer, ClusterWideConfiguration> lastClusterWideConfiguration = new ConcurrentHashMap<>();
     private final AtomicReference<RefreshStatus> refreshStatus = new AtomicReference<>(RefreshStatus.IDLE);
@@ -167,7 +168,7 @@ public class BookkeeperManager implements AutoCloseable {
         private final Map<Integer, ClusterWideConfiguration> lastClusterWideConfiguration;
 
         public RefreshCacheWorkerStatus(RefreshStatus status, long lastMetadataCacheRefresh,
-                Map<Integer, ClusterWideConfiguration> lastClusterWideConfiguration) {
+                                        Map<Integer, ClusterWideConfiguration> lastClusterWideConfiguration) {
             this.status = status;
             this.lastMetadataCacheRefresh = lastMetadataCacheRefresh;
             this.lastClusterWideConfiguration = lastClusterWideConfiguration;
@@ -281,14 +282,15 @@ public class BookkeeperManager implements AutoCloseable {
                         metadataCache.deleteBookie(b.getClusterId(), b.getBookieId());
                     }
                 }
+                Set<Long> deletedLedgers = new HashSet<>(metadataCache.listLedgers(clusterId));
 
                 Iterable<Long> ledgersIds = bkAdmin.listLedgers();
-                metadataCache.clearLedgers(clusterId);
                 for (long ledgerId : ledgersIds) {
                     LedgerMetadata ledgerMetadata = readLedgerMetadata(ledgerId, clusterId);
                     if (ledgerMetadata == null) {
                         continue;
                     }
+                    deletedLedgers.remove(ledgerId);
                     Ledger ledger = new Ledger(ledgerId, clusterId,
                             ledgerMetadata.getLength(),
                             new java.sql.Timestamp(ledgerMetadata.getCtime()),
@@ -307,6 +309,10 @@ public class BookkeeperManager implements AutoCloseable {
                     LOG.log(Level.FINE, "Updating ledger {0} metadata", ledgerId);
                     metadataCache.insertLedger(ledger, bookies, metadataEntries);
                 }
+                for (Long deletedLedger : deletedLedgers) {
+                    metadataCache.deleteLedger(clusterId, deletedLedger);
+                }
+
             }
             topologyCache.refreshBookiesTopology();
 
@@ -527,7 +533,8 @@ public class BookkeeperManager implements AutoCloseable {
                     autoRecoveryEnabled = underreplicationManager.isLedgerReplicationEnabled();
                     lostBookieRecoveryDelay = underreplicationManager.getLostBookieRecoveryDelay();
                 }
-            } catch (ReplicationException.UnavailableException | ReplicationException.CompatibilityException notConfigured) {
+            } catch (ReplicationException.UnavailableException
+                     | ReplicationException.CompatibilityException notConfigured) {
                 // auto replication stuff never initialized
                 LOG.log(Level.INFO, "Cannot get auditor info: {0}", notConfigured + ""); // do not write stacktrace
             }
@@ -541,7 +548,7 @@ public class BookkeeperManager implements AutoCloseable {
                     autoRecoveryEnabled, lostBookieRecoveryDelay,
                     layoutFormatVersion, layoutManagerFactoryClass, layoutManagerVersion);
         } catch (InterruptedException
-                | MetadataException | IOException ex) {
+                 | MetadataException | IOException ex) {
             LOG.log(Level.SEVERE, "Error", ex);
             throw new BookkeeperManagerException(ex);
         } finally {

--- a/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManager.java
+++ b/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManager.java
@@ -283,12 +283,11 @@ public class BookkeeperManager implements AutoCloseable {
                 }
 
                 Iterable<Long> ledgersIds = bkAdmin.listLedgers();
+                metadataCache.clearLedgers(clusterId);
                 for (long ledgerId : ledgersIds) {
                     LedgerMetadata ledgerMetadata = readLedgerMetadata(ledgerId, clusterId);
                     if (ledgerMetadata == null) {
-                        // ledger disappeared
-                        metadataCache.deleteLedger(clusterId, ledgerId);
-                        return;
+                        continue;
                     }
                     Ledger ledger = new Ledger(ledgerId, clusterId,
                             ledgerMetadata.getLength(),
@@ -306,7 +305,7 @@ public class BookkeeperManager implements AutoCloseable {
                         bookies.add(new LedgerBookie(ledgerId, bookieId, clusterId));
                     });
                     LOG.log(Level.FINE, "Updating ledger {0} metadata", ledgerId);
-                    metadataCache.updateLedger(ledger, bookies, metadataEntries);
+                    metadataCache.insertLedger(ledger, bookies, metadataEntries);
                 }
             }
             topologyCache.refreshBookiesTopology();

--- a/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManager.java
+++ b/web/src/main/java/org/bkvm/bookkeeper/BookkeeperManager.java
@@ -307,7 +307,7 @@ public class BookkeeperManager implements AutoCloseable {
                         bookies.add(new LedgerBookie(ledgerId, bookieId, clusterId));
                     });
                     LOG.log(Level.FINE, "Updating ledger {0} metadata", ledgerId);
-                    metadataCache.insertLedger(ledger, bookies, metadataEntries);
+                    metadataCache.updateLedger(ledger, bookies, metadataEntries);
                 }
                 for (Long deletedLedger : deletedLedgers) {
                     metadataCache.deleteLedger(clusterId, deletedLedger);

--- a/web/src/main/java/org/bkvm/cache/MetadataCache.java
+++ b/web/src/main/java/org/bkvm/cache/MetadataCache.java
@@ -215,13 +215,13 @@ public class MetadataCache implements AutoCloseable {
         }
     }
 
-    public void insertLedger(Ledger ledger, List<LedgerBookie> bookies,
+    public void updateLedger(Ledger ledger, List<LedgerBookie> bookies,
                              List<LedgerMetadataEntry> metadataEntries) {
         try (EntityManagerWrapper emw = getEntityManager()) {
             EntityManager em = emw.em;
             em.getTransaction().begin();
-            innerDeleteLedger(ledger.getClusterId(), ledger.getLedgerId(), em);
             long ledgerId = ledger.getLedgerId();
+            innerDeleteLedger(ledger.getClusterId(), ledgerId, em);
             em.persist(ledger);
             bookies.forEach((lb) -> {
                 if (ledgerId != lb.getLedgerId()) {

--- a/web/src/test/java/org/bkvm/cache/LoadMetadataCacheTest.java
+++ b/web/src/test/java/org/bkvm/cache/LoadMetadataCacheTest.java
@@ -1,0 +1,64 @@
+/*
+ Licensed to Diennea S.r.l. under one
+ or more contributor license agreements. See the NOTICE file
+ distributed with this work for additional information
+ regarding copyright ownership. Diennea S.r.l. licenses this file
+ to you under the Apache License, Version 2.0 (the
+ "License"); you may not use this file except in compliance
+ with the License.  You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing,
+ software distributed under the License is distributed on an
+ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ KIND, either express or implied.  See the License for the
+ specific language governing permissions and limitations
+ under the License.
+
+ */
+package org.bkvm.cache;
+
+import org.apache.bookkeeper.client.BookKeeper;
+import org.apache.bookkeeper.client.api.WriteHandle;
+import org.apache.bookkeeper.conf.ClientConfiguration;
+import org.bkvm.bookkeeper.BookkeeperManager;
+import org.bkvm.utils.BookkeeperManagerTestUtils;
+import org.junit.Test;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class LoadMetadataCacheTest extends BookkeeperManagerTestUtils {
+
+    @Test
+    public void testLoad() throws Exception {
+        startBookie(false, -1);
+        ClientConfiguration bkConf = new ClientConfiguration();
+        bkConf.setMetadataServiceUri(getMetadataServiceUri());
+
+        BookKeeper bk = BookKeeper.forConfig(bkConf).build();
+        WriteHandle wr = bk.newCreateLedgerOp()
+                .withAckQuorumSize(1)
+                .withEnsembleSize(1)
+                .withWriteQuorumSize(1)
+                .withPassword("p".getBytes())
+                .withCustomMetadata(Map.of("meta1", "value1".getBytes()))
+                .execute().get();
+        wr.append("test".getBytes());
+        final BookkeeperManager bookkeeperManager = getBookkeeperManager();
+        bookkeeperManager.doRefreshMetadataCache();
+        assertEquals(1, bookkeeperManager.getAllLedgers().size());
+
+        bk.newDeleteLedgerOp()
+                .withLedgerId(wr.getId())
+                .execute().get();
+        bookkeeperManager.doRefreshMetadataCache();
+        assertEquals(0, bookkeeperManager.getAllLedgers().size());
+    }
+
+}

--- a/web/src/test/java/org/bkvm/cache/MetadataCacheTest.java
+++ b/web/src/test/java/org/bkvm/cache/MetadataCacheTest.java
@@ -48,7 +48,7 @@ public class MetadataCacheTest {
                 entries.add(new LedgerMetadataEntry(1, clusterId, "other", "foo"));
                 entries.add(new LedgerMetadataEntry(1, clusterId, "metadataentry", "4933"));
                 entries.add(new LedgerMetadataEntry(1, clusterId, "metadataentry2", "Thu Aug 22 2019 12:29:58 GMT+0200 (Central European Summer Time)"));
-                metadataCache.insertLedger(ledger, lb, entries);
+                metadataCache.updateLedger(ledger, lb, entries);
                 List<Ledger> ledgers = metadataCache.listLedgers();
                 assertEquals(1, ledgers.size());
                 assertEquals(1024, ledgers.get(0).getSize());
@@ -87,7 +87,7 @@ public class MetadataCacheTest {
 
                 // UPDATE, just the size
                 Ledger ledger2 = new Ledger(1, clusterId, 2048, new java.sql.Timestamp(System.currentTimeMillis()), new java.sql.Timestamp(System.currentTimeMillis()), "");
-                metadataCache.insertLedger(ledger2, lb, entries);
+                metadataCache.updateLedger(ledger2, lb, entries);
                 List<Ledger> ledgers2 = metadataCache.listLedgers();
                 assertEquals(1, ledgers2.size());
                 assertEquals(2048, ledgers2.get(0).getSize());
@@ -105,7 +105,7 @@ public class MetadataCacheTest {
                 List<LedgerBookie> lb2 = new ArrayList<>();
                 lb2.add(new LedgerBookie(1, "localhost:1234", clusterId));
                 lb2.add(new LedgerBookie(1, "localhost:1236", clusterId));
-                metadataCache.insertLedger(ledger2rewritten, lb2, entries);
+                metadataCache.updateLedger(ledger2rewritten, lb2, entries);
 
                 assertEquals(1, metadataCache.getLedgersForBookie(clusterId, "localhost:1234").size());
                 assertEquals(0, metadataCache.getLedgersForBookie(clusterId, "localhost:1235").size());

--- a/web/src/test/java/org/bkvm/cache/MetadataCacheTest.java
+++ b/web/src/test/java/org/bkvm/cache/MetadataCacheTest.java
@@ -48,7 +48,7 @@ public class MetadataCacheTest {
                 entries.add(new LedgerMetadataEntry(1, clusterId, "other", "foo"));
                 entries.add(new LedgerMetadataEntry(1, clusterId, "metadataentry", "4933"));
                 entries.add(new LedgerMetadataEntry(1, clusterId, "metadataentry2", "Thu Aug 22 2019 12:29:58 GMT+0200 (Central European Summer Time)"));
-                metadataCache.updateLedger(ledger, lb, entries);
+                metadataCache.insertLedger(ledger, lb, entries);
                 List<Ledger> ledgers = metadataCache.listLedgers();
                 assertEquals(1, ledgers.size());
                 assertEquals(1024, ledgers.get(0).getSize());
@@ -87,7 +87,7 @@ public class MetadataCacheTest {
 
                 // UPDATE, just the size
                 Ledger ledger2 = new Ledger(1, clusterId, 2048, new java.sql.Timestamp(System.currentTimeMillis()), new java.sql.Timestamp(System.currentTimeMillis()), "");
-                metadataCache.updateLedger(ledger2, lb, entries);
+                metadataCache.insertLedger(ledger2, lb, entries);
                 List<Ledger> ledgers2 = metadataCache.listLedgers();
                 assertEquals(1, ledgers2.size());
                 assertEquals(2048, ledgers2.get(0).getSize());
@@ -105,7 +105,7 @@ public class MetadataCacheTest {
                 List<LedgerBookie> lb2 = new ArrayList<>();
                 lb2.add(new LedgerBookie(1, "localhost:1234", clusterId));
                 lb2.add(new LedgerBookie(1, "localhost:1236", clusterId));
-                metadataCache.updateLedger(ledger2rewritten, lb2, entries);
+                metadataCache.insertLedger(ledger2rewritten, lb2, entries);
 
                 assertEquals(1, metadataCache.getLedgersForBookie(clusterId, "localhost:1234").size());
                 assertEquals(0, metadataCache.getLedgersForBookie(clusterId, "localhost:1235").size());

--- a/web/src/test/java/org/bkvm/utils/BookkeeperManagerTestUtils.java
+++ b/web/src/test/java/org/bkvm/utils/BookkeeperManagerTestUtils.java
@@ -27,8 +27,6 @@ import org.bkvm.cache.Cluster;
 import org.bkvm.cache.MetadataCache;
 import org.bkvm.config.ConfigurationStore;
 import org.bkvm.config.PropertiesConfigurationStore;
-import org.bkvm.config.ServerConfiguration;
-import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 

--- a/web/src/test/java/org/bkvm/utils/BookkeeperManagerTestUtils.java
+++ b/web/src/test/java/org/bkvm/utils/BookkeeperManagerTestUtils.java
@@ -28,6 +28,7 @@ import org.bkvm.cache.MetadataCache;
 import org.bkvm.config.ConfigurationStore;
 import org.bkvm.config.PropertiesConfigurationStore;
 import org.bkvm.config.ServerConfiguration;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 
@@ -55,17 +56,17 @@ public class BookkeeperManagerTestUtils extends AbstractBookkeeperTestUtils {
         datasource = new HerdDBEmbeddedDataSource();
         datasource.setUrl("jdbc:herddb:local");
         metadataCache = new MetadataCache(datasource);
-        final Properties properties = new Properties();
-        properties.put(ServerConfiguration.PROPERTY_BOOKKEEPER_METADATA_SERVICE_URI,
-                "zk+null://" + getZooKeeperAddress() + "/ledgers");
-
         ConfigurationStore config = new PropertiesConfigurationStore(new Properties());
         bookkeeperManager = new BookkeeperManager(config, metadataCache);
         init();
     }
 
     protected void init() throws Exception {
-        createCluster("cluster1", "zk+null://" + getZooKeeperAddress() + "/ledgers", "");
+        createCluster("cluster1", getMetadataServiceUri(), "");
+    }
+
+    protected String getMetadataServiceUri() {
+        return "zk+null://" + getZooKeeperAddress() + "/ledgers";
     }
 
     protected Cluster createCluster(String name, String metadataServiceUri, String configuration) throws BookkeeperManagerException {


### PR DESCRIPTION
In production clusters using Pulsar we noticed deleted ledgers are not removed from the cache.

Fixes:
* Clear all ledgers during the refresh
* Update lombok and surefire to run tests with JDK21