### PR TITLE
Increase memory limits to 4Gi to match Java heap space configuration

### DIFF
--- a/kubernetes/bkvm/values.yaml
+++ b/kubernetes/bkvm/values.yaml
@@ -23,7 +23,7 @@ server:
 
   image:
     repository: herddb/bkvm
-    tag: 3.2.0
+    tag: latest
     imagePullPolicy: IfNotPresent
   
   jdbcUrl: jdbc:herddb:local:temporary
@@ -63,10 +63,10 @@ server:
   resources:
     requests:
       cpu: "0.5"
-      memory: "1Gi"
+      memory: "4Gi"
     limits:
       cpu: "0.5"
-      memory: "1Gi"
+      memory: "4Gi"
 
   rbac:
     create: true


### PR DESCRIPTION
- **Memory Limits:** Increases the memory resource limits from 1Gi to 4Gi to align with the Java heap space configuration. This adjustment ensures that the application has adequate resources for optimal performance and stability.
- **Image Tag:** Updates the container image to use the latest tag for herddb/bkvm instead of 3.2.0. This change allows us to benefit from the most recent features and fixes included in the latest image.